### PR TITLE
Update Mercedes-Benz GLC-Class generations: Add generation data and Wikipedia references

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
-# Model make
+# Mercedes-Benz GLC-Class
 
+This repository contains signal set configurations for the Mercedes-Benz GLC-Class, organized by model year and version. The files are structured to allow for easy differentiation between model generations and other vehicle parameters, ensuring accurate signal mapping for each version of the Mercedes-Benz GLC-Class.
+
+## Contributing
+
+Contributions are welcome! If you would like to add support for additional model years or other configurations, please open an issue or submit a pull request.
+
+1. Fork the repository
+2. Create a new branch for your changes
+3. Commit your changes and open a pull request with a detailed description
+
+## Issues
+
+If you encounter any issues or would like to discuss improvements, please feel free to open an issue. We encourage collaboration and appreciate feedback to make the repository as accurate and useful as possible.

--- a/generations.yaml
+++ b/generations.yaml
@@ -1,0 +1,12 @@
+references:
+  - "https://en.wikipedia.org/wiki/Mercedes-Benz_GLC"
+
+generations:
+  - name: "First generation"
+    start_year: 2015
+    end_year: 2022
+    description: "The first-generation GLC (X253/C253) replaced the GLK-Class. It introduced the GLC Coupé variant with a sloping roof design. Available in both SUV and Coupé body styles across multiple markets with various petrol diesel and hybrid powertrains."
+  - name: "Second generation"
+    start_year: 2022
+    end_year: null
+    description: "The second-generation GLC (X254/C254) was unveiled in June 2022 with modernized styling and expanded electrified options. Features include four-cylinder engines with mild hybrid technology as standard, three plug-in hybrid variants, and is produced in Germany, China, Thailand, Indonesia and Malaysia."


### PR DESCRIPTION
- Added First Generation (X253/C253): 2015-2022
- Added Second Generation (X254/C254): 2022-present
- Added comprehensive Wikipedia reference: https://en.wikipedia.org/wiki/Mercedes-Benz_GLC
- Updated README.md with standard template

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>
