### PR TITLE
Update Mercedes-Benz GLC generations: Split first generation by facelift

### DIFF
--- a/generations.yaml
+++ b/generations.yaml
@@ -2,10 +2,14 @@ references:
   - "https://en.wikipedia.org/wiki/Mercedes-Benz_GLC"
 
 generations:
-  - name: "First generation"
+  - name: "First generation (pre-facelift)"
     start_year: 2015
+    end_year: 2019
+    description: "The first-generation GLC (X253/C253) replaced the GLK-Class. It introduced the GLC Coupé variant with a sloping roof design. Available in both SUV and Coupé body styles across multiple markets with various petrol, diesel, and hybrid powertrains. Pre-facelift models feature the original front fascia design and first-generation MBUX system."
+  - name: "First generation (facelift)"
+    start_year: 2020
     end_year: 2022
-    description: "The first-generation GLC (X253/C253) replaced the GLK-Class. It introduced the GLC Coupé variant with a sloping roof design. Available in both SUV and Coupé body styles across multiple markets with various petrol diesel and hybrid powertrains."
+    description: "The facelifted first-generation GLC (X253/C253) was unveiled at the 2019 Geneva Motor Show. Updated features include the new MBUX Operating System activated by voice command, a new steering wheel, a 12.3-inch digital cockpit, and updated engines with improved efficiency."
   - name: "Second generation"
     start_year: 2022
     end_year: null


### PR DESCRIPTION
- Separated first generation (X253/C253) into pre-facelift (2015-2019) and facelift (2020-2022) entries
- Facelift introduced at 2019 Geneva Motor Show with new MBUX Operating System, digital cockpit, and updated styling
- This captures visual differences for ML training purposes
- Second generation (X254/C254) remains unchanged (2022-present)

Evidence: Wikipedia article confirms facelift for 2020 model year with updated exterior and interior features
